### PR TITLE
fix an error on input data

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,12 +9,17 @@ import (
 )
 
 func main() {
-	ret, err := resource.LoadFromPath(context.Background(), "/Users/weih/projects/25-kubecon-jp/tenants/foo/dev/resource.pkl")
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	for _, ns := range ret.Kubernetes.Namespaces {
-		fmt.Println(ns)
+	pkls := []string{"tenants/bar/prod/resource.pkl", "tenants/foo/dev/resource.pkl"}
+
+	for _, pkl := range pkls {
+		fmt.Printf("===%s===\n", pkl)
+		ret, err := resource.LoadFromPath(context.Background(), pkl)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		for _, ns := range ret.Kubernetes.Namespaces {
+			fmt.Println(ns)
+		}
 	}
 }

--- a/tenants/bar/prod/resource.pkl
+++ b/tenants/bar/prod/resource.pkl
@@ -18,7 +18,9 @@ kubernetes = new ResourceConfig.Kubernetes {
   selector = module.selector
 }
 
-buckets = new ResourceConfig.Bucket {
-  name = "bar-bucket-"
-  selector = module.selector
+buckets = new Listing<ResourceConfig.Bucket> {
+  new {
+    name = "bar-bucket-"
+    selector = module.selector
+  }
 }

--- a/tenants/foo/dev/resource.pkl
+++ b/tenants/foo/dev/resource.pkl
@@ -19,14 +19,16 @@ kubernetes = new ResourceConfig.Kubernetes {
   selector = module.selector
 }
 
-buckets = new ResourceConfig.Bucket {
-  name = "foo-bucket-"
-  selector = (module.selector) {
-    new {
-      key = "cloud_provider"
-      operator = "In"
-      values {
-        "gcp"
+buckets = new Listing<ResourceConfig.Bucket> {
+  new {
+    name = "foo-bucket-"
+    selector = (module.selector) {
+      new {
+        key = "cloud_provider"
+        operator = "In"
+        values {
+          "gcp"
+        }
       }
     }
   }


### PR DESCRIPTION
The schema defines `buckets` as a `Listing`, so if we define the data as:

```pkl
buckets = new ResourceConfig.Bucket {
```

when using the Go codegen `LoadFromPath()`, it'd fail with:

```console
expected array length 2 but got 4
```

(similar like https://github.com/apple/pkl-go/issues/91)

/kind bug