### PR TITLE
another bucket codegen demo

### DIFF
--- a/infra/account.pkl
+++ b/infra/account.pkl
@@ -8,9 +8,5 @@ accounts = new Listing<AccountConfig.Account> {
   new {
     accountID = "lustrous-baton-460122-u7"
     cloudProvider = "gcp"
-    tags {
-      // It's a dev account.
-      ["env"] = "dev"
-    }
   }
 }

--- a/tenants/tenant-X/prod/resource.pkl
+++ b/tenants/tenant-X/prod/resource.pkl
@@ -1,0 +1,14 @@
+import ".../schema/tenant/ResourceConfig.pkl"
+
+kubernetes = new ResourceConfig.Kubernetes {
+  namespaces = new {
+    "x"
+  }
+}
+
+buckets = new Listing<ResourceConfig.Bucket> {
+  new {
+    name = "x"
+    region = "us-east-1"
+  }
+}

--- a/tenants/tenant-Y/dev/resource.pkl
+++ b/tenants/tenant-Y/dev/resource.pkl
@@ -1,29 +1,17 @@
 import ".../schema/tenant/ResourceConfig.pkl"
-import ".../schema/tenant/SelectorConfig.pkl"
-
-hidden selector = new Listing<SelectorConfig.Requirment> {
-  new {
-    key = "env"
-    operator = "In"
-    values {
-      "dev"
-    }
-  }
-}
 
 kubernetes = new ResourceConfig.Kubernetes {
   namespaces = new {
-    "foo1"
-    "foo2"
+    "y1"
+    "y2"
   }
-  selector = module.selector
 }
 
 buckets = new Listing<ResourceConfig.Bucket> {
   new {
-    name = "foo"
+    name = "y-temp"
     region = "us-west-2"
-    selector = (module.selector) {
+    selector {
       new {
         key = "cloudProvider"
         operator = "In"

--- a/tenants/tenant-Y/prod/resource.pkl
+++ b/tenants/tenant-Y/prod/resource.pkl
@@ -1,26 +1,25 @@
 import ".../schema/tenant/ResourceConfig.pkl"
 import ".../schema/tenant/SelectorConfig.pkl"
 
-hidden selector = new Listing<SelectorConfig.Requirment> {
-  new {
-    key = "env"
-    operator = "In"
-    values {
-      "prod"
-    }
-  }
-}
-
 kubernetes = new ResourceConfig.Kubernetes {
   namespaces = new {
-    "bar"
+    "y1"
+    "y2"
   }
-  selector = module.selector
 }
 
 buckets = new Listing<ResourceConfig.Bucket> {
   new {
-    name = "bar"
-    region = "us-east-1"
+    name = "y"
+    region = "us-west-2"
+    selector {
+      new {
+        key = "cloudProvider"
+        operator = "In"
+        values {
+          "aws"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
- rename tenant's names to `tenant-X` and `tenant-Y`
- uplift restrictions on accounts