### PR TITLE
demo: restrict aws account to be env=prod

### DIFF
--- a/infra/account.pkl
+++ b/infra/account.pkl
@@ -4,6 +4,9 @@ accounts = new Listing<AccountConfig.Account> {
   new {
     accountID = "644604562971"
     cloudProvider = "aws"
+    tags {
+      ["env"] = "prod"
+    }
   }
   new {
     accountID = "lustrous-baton-460122-u7"

--- a/tenants/tenant-y/prod/resource.pkl
+++ b/tenants/tenant-y/prod/resource.pkl
@@ -1,5 +1,4 @@
 import ".../schema/tenant/ResourceConfig.pkl"
-import ".../schema/tenant/SelectorConfig.pkl"
 
 kubernetes = new ResourceConfig.Kubernetes {
   namespaces = new {


### PR DESCRIPTION
A demo to restrict aws account to be env=prod.